### PR TITLE
Update thresholds and report options

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -768,7 +768,13 @@ if selected_tab == "Analisis Baru":
                         fv.run_tahap_4_visualisasi_dan_penilaian(result, tmpdir_path)
 
                         st.write("Tahap 5: Menyusun Laporan PDF & Validasi...")
-                        fv.run_tahap_5_pelaporan_dan_validasi(result, tmpdir_path, baseline_result)
+                        fv.run_tahap_5_pelaporan_dan_validasi(
+                            result,
+                            tmpdir_path,
+                            baseline_result,
+                            include_simple=show_simple_explanations,
+                            include_technical=show_technical_details,
+                        )
                         
                         status.update(label="✅ Analisis 5 Tahap Forensik Berhasil!", state="complete", expanded=False)
                 


### PR DESCRIPTION
## Summary
- allow user-provided SSIM and optical flow thresholds
- support toggling simple and technical explanations in PDF report
- expose threshold options in the Streamlit front-end

## Testing
- `pytest -q` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_6859ae3eeb30832ca67cacf581edc1c2